### PR TITLE
add codec options for auto tag handling with (Un)Marshaler types

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -3063,15 +3063,16 @@ func TestUnmarshalToNotNilInterface(t *testing.T) {
 
 func TestDecOptions(t *testing.T) {
 	opts1 := DecOptions{
-		TimeTag:           DecTagRequired,
-		DupMapKey:         DupMapKeyEnforcedAPF,
-		IndefLength:       IndefLengthForbidden,
-		MaxNestedLevels:   100,
-		MaxMapPairs:       101,
-		MaxArrayElements:  102,
-		TagsMd:            TagsForbidden,
-		IntDec:            IntDecConvertSigned,
-		ExtraReturnErrors: ExtraDecErrorUnknownField,
+		TimeTag:                 DecTagRequired,
+		DupMapKey:               DupMapKeyEnforcedAPF,
+		IndefLength:             IndefLengthForbidden,
+		MaxNestedLevels:         100,
+		MaxMapPairs:             101,
+		MaxArrayElements:        102,
+		TagsMd:                  TagsForbidden,
+		IntDec:                  IntDecConvertSigned,
+		ExtraReturnErrors:       ExtraDecErrorUnknownField,
+		HandleTagForUnmarshaler: true,
 	}
 	dm, err := opts1.DecMode()
 	if err != nil {


### PR DESCRIPTION
Per default, a type implementing the Marshaler or Unmarshaler interfaces is expected to encode or decode CBOR tags itself, even if the type is registered to a TagSet. 

Setting the new `HandleTagForMarshaler` encoder option or `HandleTagForUnmarshaler` decoder option to true activates automatic tag handling for Marshaler/Unmarshaler types in the same way that this is implemented for all other types. I.e. the Marshaler/Unmarshaler code does not have to deal with the tags. 

This decouples the use of tags from the (un)marshaling code and makes it less error-prone: with the default implementation, a marshaler could use a different tag number than what is specified in the TagSet or no tag at all...
