### PR TITLE
improve compatibility with encoding/json: add option FloatToInt

### DIFF
--- a/common.go
+++ b/common.go
@@ -113,6 +113,7 @@ const (
 	tagNumExpectedLaterEncodingBase64URL = 21
 	tagNumExpectedLaterEncodingBase64    = 22
 	tagNumExpectedLaterEncodingBase16    = 23
+	tagNumJsonNumber                     = 284
 	tagNumSelfDescribedCBOR              = 55799
 )
 
@@ -177,6 +178,17 @@ func validBuiltinTag(tagNum uint64, contentHead byte) error {
 		//   item, except for those contained in a nested data item tagged with an expected
 		//   conversion.
 		return nil
+
+	case tagNumJsonNumber:
+		// Tag content must be string type.
+		if t != cborTypeTextString && t != cborTypeByteString {
+			return newInadmissibleTagContentTypeError(
+				tagNumJsonNumber,
+				"text or byte string",
+				t.String())
+		}
+		return nil
+
 	}
 
 	return nil

--- a/decode.go
+++ b/decode.go
@@ -769,6 +769,31 @@ func (tum TextUnmarshalerMode) valid() bool {
 	return tum >= 0 && tum < maxTextUnmarshalerMode
 }
 
+// FloatToIntMode specifies how to decode float into integer types when decoding
+// into structs with integer fields as it may happen when the cbor was encoded
+// from a JSON decoded structure.
+type FloatToIntMode int
+
+const (
+	// FloatToIntNone disallows conversion
+	FloatToIntNone FloatToIntMode = iota
+
+	// FloatToIntExact allows conversion, provided accuracy is exact.
+	FloatToIntExact FloatToIntMode = iota
+
+	// FloatToIntLenient allows conversion even if accuracy is not exact. This
+	// may be useful in round trips from JSON with large int64/uint64 values.
+	// This results in a behavior similar to an encoding/json decoder not using
+	// the 'UseNumber' configuration.
+	FloatToIntLenient
+
+	maxFloatToIntMode
+)
+
+func (fti FloatToIntMode) valid() bool {
+	return fti >= 0 && fti < maxFloatToIntMode
+}
+
 // DecOptions specifies decoding options.
 type DecOptions struct {
 	// DupMapKey specifies whether to enforce duplicate map key.
@@ -918,6 +943,13 @@ type DecOptions struct {
 	// implement json.Unmarshaler but do not also implement cbor.Unmarshaler. If nil, decoding
 	// behavior is not influenced by whether or not a type implements json.Unmarshaler.
 	JSONUnmarshalerTranscoder Transcoder
+
+	// FloatToInt specifies whether conversion from float to int has to be exact.
+	// Default value (FloatToIntNone) does not allow conversion
+	// FloatToIntExact requires 'exact' conversion, while
+	// FloatToIntLenient enables lenient conversion similar to the behavior of
+	// encoding/json when not using 'UseNumber'.
+	FloatToInt FloatToIntMode
 }
 
 // DecMode returns DecMode with immutable options and no tags (safe for concurrency).
@@ -1134,6 +1166,10 @@ func (opts DecOptions) decMode() (*decMode, error) { //nolint:gocritic // ignore
 		return nil, errors.New("cbor: invalid TextUnmarshaler " + strconv.Itoa(int(opts.TextUnmarshaler)))
 	}
 
+	if !opts.FloatToInt.valid() {
+		return nil, errors.New("cbor: invalid FloatToInt " + strconv.Itoa(int(opts.FloatToInt)))
+	}
+
 	dm := decMode{
 		dupMapKey:                 opts.DupMapKey,
 		timeTag:                   opts.TimeTag,
@@ -1164,6 +1200,7 @@ func (opts DecOptions) decMode() (*decMode, error) { //nolint:gocritic // ignore
 		binaryUnmarshaler:         opts.BinaryUnmarshaler,
 		textUnmarshaler:           opts.TextUnmarshaler,
 		jsonUnmarshalerTranscoder: opts.JSONUnmarshalerTranscoder,
+		floatToInt:                opts.FloatToInt,
 	}
 
 	return &dm, nil
@@ -1246,6 +1283,7 @@ type decMode struct {
 	binaryUnmarshaler         BinaryUnmarshalerMode
 	textUnmarshaler           TextUnmarshalerMode
 	jsonUnmarshalerTranscoder Transcoder
+	floatToInt                FloatToIntMode
 }
 
 var defaultDecMode, _ = DecOptions{}.decMode()
@@ -1289,6 +1327,7 @@ func (dm *decMode) DecOptions() DecOptions {
 		BinaryUnmarshaler:         dm.binaryUnmarshaler,
 		TextUnmarshaler:           dm.textUnmarshaler,
 		JSONUnmarshalerTranscoder: dm.jsonUnmarshalerTranscoder,
+		FloatToInt:                dm.floatToInt,
 	}
 }
 
@@ -1590,15 +1629,15 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 		switch ai {
 		case additionalInformationAsFloat16:
 			f := float64(float16.Frombits(uint16(val)).Float32()) //nolint:gosec
-			return fillFloat(t, f, v)
+			return fillFloat(t, f, v, d.dm.floatToInt)
 
 		case additionalInformationAsFloat32:
 			f := float64(math.Float32frombits(uint32(val))) //nolint:gosec
-			return fillFloat(t, f, v)
+			return fillFloat(t, f, v, d.dm.floatToInt)
 
 		case additionalInformationAsFloat64:
 			f := math.Float64frombits(val)
-			return fillFloat(t, f, v)
+			return fillFloat(t, f, v, d.dm.floatToInt)
 
 		default: // ai <= 24
 			if d.dm.simpleValues.rejected[SimpleValue(val)] { //nolint:gosec
@@ -1677,6 +1716,54 @@ func (d *decoder) parseToValue(v reflect.Value, tInfo *typeInfo) error { //nolin
 				defer func() {
 					d.expectedLaterEncodingTags = d.expectedLaterEncodingTags[:len(d.expectedLaterEncodingTags)-1]
 				}()
+			}
+
+		case tagNumJsonNumber:
+			num := ""
+			jt := d.nextCBORType()
+			switch jt {
+			case cborTypeByteString:
+				b, _ := d.parseByteString()
+				num = string(b)
+			case cborTypeTextString:
+				b, _ := d.parseTextString()
+				num = string(b)
+			}
+			if num != "" {
+				switch v.Kind() {
+				case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8:
+					iv, err := strconv.ParseInt(num, 10, 64)
+					if err != nil {
+						return &UnmarshalTypeError{
+							CBORType: t.String(),
+							GoType:   tInfo.nonPtrType.String(),
+							errorMsg: num + " cannot be parsed as " + v.Type().String() + ": " + err.Error(),
+						}
+					}
+					return fillNegativeInt(jt, iv, v)
+
+				case reflect.Uint, reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
+					iv, err := strconv.ParseUint(num, 10, 64)
+					if err != nil {
+						return &UnmarshalTypeError{
+							CBORType: t.String(),
+							GoType:   tInfo.nonPtrType.String(),
+							errorMsg: num + " cannot be parsed as " + v.Type().String() + ": " + err.Error(),
+						}
+					}
+					return fillPositiveInt(jt, iv, v)
+
+				case reflect.Float32, reflect.Float64:
+					fv, err := strconv.ParseFloat(num, 64)
+					if err != nil {
+						return &UnmarshalTypeError{
+							CBORType: t.String(),
+							GoType:   tInfo.nonPtrType.String(),
+							errorMsg: num + " cannot be parsed as " + v.Type().String() + ": " + err.Error(),
+						}
+					}
+					return fillFloat(jt, fv, v, d.dm.floatToInt)
+				}
 			}
 		}
 
@@ -3169,7 +3256,7 @@ func fillBool(t cborType, val bool, v reflect.Value) error {
 	return &UnmarshalTypeError{CBORType: t.String(), GoType: v.Type().String()}
 }
 
-func fillFloat(t cborType, val float64, v reflect.Value) error {
+func fillFloat(t cborType, val float64, v reflect.Value, mode FloatToIntMode) error {
 	switch v.Kind() {
 	case reflect.Float32, reflect.Float64:
 		if v.OverflowFloat(val) {
@@ -3181,6 +3268,54 @@ func fillFloat(t cborType, val float64, v reflect.Value) error {
 		}
 		v.SetFloat(val)
 		return nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if mode != FloatToIntNone {
+			var ival int64
+			ok := false
+			if !math.IsNaN(val) { // NewFloat panics with NaN
+				fl := big.NewFloat(val)
+				if fl.IsInt() {
+					var acc big.Accuracy
+					ival, acc = fl.Int64()
+					ok = acc == big.Exact || mode == FloatToIntLenient
+				}
+			}
+			if ok {
+				if v.OverflowInt(ival) {
+					return &UnmarshalTypeError{
+						CBORType: t.String(),
+						GoType:   v.Type().String(),
+						errorMsg: strconv.FormatFloat(val, 'E', -1, 64) + " overflows " + v.Type().String(),
+					}
+				}
+				v.SetInt(ival)
+				return nil
+			}
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if mode != FloatToIntNone {
+			var ival uint64
+			ok := false
+			if !math.IsNaN(val) { // NewFloat panics with NaN
+				fl := big.NewFloat(val)
+				if fl.IsInt() {
+					var acc big.Accuracy
+					ival, acc = fl.Uint64()
+					ok = acc == big.Exact || mode == FloatToIntLenient
+				}
+			}
+			if ok {
+				if v.OverflowUint(ival) {
+					return &UnmarshalTypeError{
+						CBORType: t.String(),
+						GoType:   v.Type().String(),
+						errorMsg: strconv.FormatFloat(val, 'E', -1, 64) + " overflows " + v.Type().String(),
+					}
+				}
+				v.SetUint(ival)
+				return nil
+			}
+		}
 	}
 	return &UnmarshalTypeError{CBORType: t.String(), GoType: v.Type().String()}
 }

--- a/decode_test.go
+++ b/decode_test.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"math/big"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -5559,6 +5560,7 @@ func TestDecOptions(t *testing.T) {
 		BinaryUnmarshaler:         BinaryUnmarshalerNone,
 		TextUnmarshaler:           TextUnmarshalerTextString,
 		JSONUnmarshalerTranscoder: stubTranscoder{},
+		FloatToInt:                FloatToIntLenient,
 	}
 	ov := reflect.ValueOf(opts1)
 	for i := range ov.NumField() {
@@ -11212,5 +11214,317 @@ func TestByteStringExpectedFormatErrorDefaultCase(t *testing.T) {
 	want := "cbor: failed to decode byte string in expected format 99: test error"
 	if got != want {
 		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestIntRoundtripJsonCbor(t *testing.T) {
+
+	type structInt struct {
+		I int64  `json:"i"`
+		U uint64 `json:"u"`
+	}
+	// structIntAsFloat has the same structure as structInt and is used to test errors
+	type structIntAsFloat struct {
+		I float64 `json:"i"`
+		U float64 `json:"u"`
+	}
+
+	type testCase struct {
+		name    string
+		in      *structInt
+		inAs    *structIntAsFloat
+		lenient bool
+		want    any
+		wantErr bool
+	}
+	enc := defaultEncMode
+
+	_, err := DecOptions{FloatToInt: 48}.decMode()
+	if err == nil {
+		t.Fatalf("expected error (invalid FloatToInt), got nil")
+	}
+
+	for _, tc := range []*testCase{
+		{name: "regular", in: &structInt{I: 123, U: 456}, want: &structInt{I: 123, U: 456}},
+		{name: "regular-float", inAs: &structIntAsFloat{I: 123, U: 456}, want: &structInt{I: 123, U: 456}},
+		{name: "nan-int64", inAs: &structIntAsFloat{I: math.NaN(), U: 456}, wantErr: true},
+		{name: "nan-uint64", inAs: &structIntAsFloat{I: 123, U: math.NaN()}, wantErr: true},
+		{name: "inf-int64", inAs: &structIntAsFloat{I: math.Inf(1), U: 456}, wantErr: true},
+		{name: "inf-uint64", inAs: &structIntAsFloat{I: 123, U: math.Inf(-1)}, wantErr: true},
+		{name: "max-err", in: &structInt{I: math.MaxInt64, U: math.MaxUint64},
+			wantErr: true, // big.Float.Int64() returns accuracy 'below'
+		},
+		{name: "max", in: &structInt{I: math.MaxInt64, U: math.MaxUint64},
+			lenient: true,
+			want: &structInt{
+				I: 9223372036854775807,
+				U: 18446744073709551615,
+			}},
+	} {
+		var cborBytes []byte
+		var err error
+		dec, _ := DecOptions{FloatToInt: FloatToIntExact}.decMode()
+		if tc.lenient {
+			dec, _ = DecOptions{FloatToInt: FloatToIntLenient}.decMode()
+		}
+
+		if tc.in != nil {
+			var bb []byte
+			bb, err = json.Marshal(tc.in)
+			if err != nil {
+				t.Errorf("%s: json marshal returned non-nil error %v", tc.name, err)
+				continue
+			}
+			var gen any
+			err = json.Unmarshal(bb, &gen)
+			if err != nil {
+				t.Errorf("%s: json unmarshal returned non-nil error %v", tc.name, err)
+				continue
+			}
+			cborBytes, err = enc.Marshal(&gen)
+		} else {
+			cborBytes, err = enc.Marshal(tc.inAs)
+		}
+		if err != nil {
+			t.Errorf("%s: marshal returned non-nil error %v", tc.name, err)
+			continue
+		}
+
+		target := &structInt{}
+		err = dec.Unmarshal(cborBytes, target)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: expected error, got nil", tc.name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unmarshal returned non-nil error %v", tc.name, err)
+			continue
+		}
+		if !reflect.DeepEqual(tc.want, target) {
+			t.Errorf("expected: %v, got: %v", tc.want, target)
+		}
+	}
+
+}
+
+func TestJsonNumber(t *testing.T) {
+
+	type serial struct {
+		Ts  int64  `json:"ts"`
+		Uts uint64 `json:"uts"`
+	}
+
+	// Register tag CBOR JSON NUMBER 284
+	tags := NewTagSet()
+	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired},
+		reflect.TypeOf(json.Number("")), tagNumJsonNumber); err != nil {
+		t.Fatal("TagSet.Add:", err)
+	}
+	// Create Enc/DecMode with tags
+	dm, _ := DecOptions{}.DecModeWithTags(tags)
+	emTextString, _ := EncOptions{}.EncModeWithTags(tags)
+	emByteString, _ := EncOptions{String: StringToByteString}.EncModeWithTags(tags)
+
+	//2026-01-14 20:28:51.241044 +0000 UTC
+	now := int64(1768422531)
+	snow := "1768422531"
+	maxInt64 := int64(math.MaxInt64)
+	smaxInt64 := strconv.FormatInt(maxInt64, 10)
+	maxUint64 := uint64(math.MaxUint64)
+	smaxUint64 := strconv.FormatUint(maxUint64, 10)
+
+	encodeWithText := func(m map[string]interface{}) []byte {
+		ret, err := emTextString.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return ret
+	}
+
+	// special encoding func that makes map keys with 'text' string and values with 'byte' string
+	encodeWithByte := func(m map[string]interface{}) []byte {
+		e := bytes.NewBuffer(make([]byte, 0, 100))
+		encodeHead(e, byte(cborTypeMap), uint64(2))
+		err := encodeString(e, emTextString.(*encMode), reflect.ValueOf("ts"))
+		if err != nil {
+			t.Fatalf("encodeString: %v", err)
+		}
+		err = encodeString(e, emByteString.(*encMode), reflect.ValueOf(m["ts"]))
+		if err != nil {
+			t.Fatalf("encodeString: %v", err)
+		}
+		err = encodeString(e, emTextString.(*encMode), reflect.ValueOf("uts"))
+		if err != nil {
+			t.Fatalf("encodeString: %v", err)
+		}
+		err = encodeString(e, emByteString.(*encMode), reflect.ValueOf(m["uts"]))
+		if err != nil {
+			t.Fatalf("encodeString: %v", err)
+		}
+		return e.Bytes()
+	}
+
+	type testCase struct {
+		// in is a map as produced by serializing to json, then decoding from
+		// json with the decoder configured with UseNumber
+		in      map[string]interface{}
+		name    string
+		em      func(m map[string]interface{}) []byte
+		wantErr bool
+		want    any
+	}
+	for _, tc := range []*testCase{
+		{name: "regular-text",
+			in:   map[string]interface{}{"ts": json.Number(snow), "uts": json.Number(snow)},
+			em:   encodeWithText,
+			want: &serial{Ts: now, Uts: uint64(now)}},
+		{name: "regular-byte",
+			in:   map[string]interface{}{"ts": json.Number(snow), "uts": json.Number(snow)},
+			em:   encodeWithByte,
+			want: &serial{Ts: now, Uts: uint64(now)}},
+		{name: "error-text",
+			in:      map[string]interface{}{"ts": json.Number("snow"), "uts": json.Number("snow")},
+			em:      encodeWithText,
+			wantErr: true},
+		{name: "error-byte",
+			in:      map[string]interface{}{"ts": json.Number("snow"), "uts": json.Number("snow")},
+			em:      encodeWithByte,
+			wantErr: true},
+		{name: "max-text",
+			in:   map[string]interface{}{"ts": json.Number(smaxInt64), "uts": json.Number(smaxUint64)},
+			em:   encodeWithText,
+			want: &serial{Ts: maxInt64, Uts: maxUint64}},
+		{name: "max-byte",
+			in:   map[string]interface{}{"ts": json.Number(smaxInt64), "uts": json.Number(smaxUint64)},
+			em:   encodeWithByte,
+			want: &serial{Ts: maxInt64, Uts: maxUint64}},
+	} {
+
+		cborBytes := tc.em(tc.in)
+		//{
+		//	diag, err := Diagnose(cborBytes)
+		//	if err != nil {
+		//		t.Fatalf("%s: unexpected error %v", tc.name, err)
+		//	}
+		//	fmt.Println(diag)
+		//}
+		dec := dm.NewDecoder(bytes.NewReader(cborBytes))
+
+		ts := &serial{}
+		err := dec.Decode(ts)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: expected error, got nil", tc.name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error %v", tc.name, err)
+			continue
+		}
+		if !reflect.DeepEqual(tc.want, ts) {
+			t.Errorf("%s: expected: %v, got: %v", tc.name, tc.want, ts)
+		}
+	}
+}
+
+func TestJsonNumberFloat(t *testing.T) {
+
+	type serial struct {
+		Ts float64 `json:"ts"`
+	}
+
+	// Register tag CBOR JSON NUMBER 284
+	tags := NewTagSet()
+	if err := tags.Add(TagOptions{EncTag: EncTagRequired, DecTag: DecTagRequired},
+		reflect.TypeOf(json.Number("")), tagNumJsonNumber); err != nil {
+		t.Fatal("TagSet.Add:", err)
+	}
+	// Create Enc/DecMode with tags
+	dm, _ := DecOptions{}.DecModeWithTags(tags)
+	emTextString, _ := EncOptions{}.EncModeWithTags(tags)
+	emByteString, _ := EncOptions{String: StringToByteString}.EncModeWithTags(tags)
+
+	now := 1768422.531
+	snow := "1768422.531"
+
+	encodeWithText := func(m map[string]interface{}) []byte {
+		ret, err := emTextString.Marshal(m)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return ret
+	}
+
+	// special encoding func that makes map keys with 'text' string and values with 'byte' string
+	encodeWithByte := func(m map[string]interface{}) []byte {
+		e := bytes.NewBuffer(make([]byte, 0, 100))
+		encodeHead(e, byte(cborTypeMap), uint64(1))
+		err := encodeString(e, emTextString.(*encMode), reflect.ValueOf("ts"))
+		if err != nil {
+			t.Fatalf("encodeString: %v", err)
+		}
+		err = encodeString(e, emByteString.(*encMode), reflect.ValueOf(m["ts"]))
+		if err != nil {
+			t.Fatalf("encodeString: %v", err)
+		}
+		return e.Bytes()
+	}
+
+	type testCase struct {
+		// in is a map as produced by serializing to json, then decoding from
+		// json with the decoder configured with UseNumber
+		in      map[string]interface{}
+		name    string
+		em      func(m map[string]interface{}) []byte
+		wantErr bool
+		want    any
+	}
+	for _, tc := range []*testCase{
+		{name: "regular-text",
+			in:   map[string]interface{}{"ts": json.Number(snow)},
+			em:   encodeWithText,
+			want: &serial{Ts: now}},
+		{name: "regular-byte",
+			in:   map[string]interface{}{"ts": json.Number(snow)},
+			em:   encodeWithByte,
+			want: &serial{Ts: now}},
+		{name: "error-text",
+			in:      map[string]interface{}{"ts": json.Number("snow")},
+			em:      encodeWithText,
+			wantErr: true},
+		{name: "error-byte",
+			in:      map[string]interface{}{"ts": json.Number("snow")},
+			em:      encodeWithByte,
+			wantErr: true},
+	} {
+
+		cborBytes := tc.em(tc.in)
+		//{
+		//	diag, err := Diagnose(cborBytes)
+		//	if err != nil {
+		//		t.Fatalf("%s: unexpected error %v", tc.name, err)
+		//	}
+		//	fmt.Println(diag)
+		//}
+		dec := dm.NewDecoder(bytes.NewReader(cborBytes))
+
+		ts := &serial{}
+		err := dec.Decode(ts)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: expected error, got nil", tc.name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error %v", tc.name, err)
+			continue
+		}
+		if !reflect.DeepEqual(tc.want, ts) {
+			t.Errorf("%s: expected: %v, got: %v", tc.name, tc.want, ts)
+		}
 	}
 }


### PR DESCRIPTION
issue: https://github.com/fxamacker/cbor/issues/439

improve compatibility with encoding/json: 
* add option FloatToInt
* add support for tagNumJsonNumber (284)

**note**: 
* this PR will need to be targeted to branch `customizations` once #5 is merged.
* using `update-customizations` as the target branch for now

This covers cases where some json is received (e.g. on an API server), decoded via encoding/json before being cbor encoded. The json decoder can be configured with or without the UseNumber option of the json decoder.

The proposed changes:
* provide an 'opt-in' option to allow float to int conversion. This covers the case where json is decoded without the `UseNumber` option (and thus results in float values).
* adding support for JSON number (tag 284). This covers the case where the `UseNumber` option is used.

These changes do not modify the existing behavior since float-to-int is opt-in and support for JSON numbers has to be configured on the cbor encoder.
